### PR TITLE
server/database: add a limit to the number of open DB connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 before_install:
 - go get github.com/constabulary/gb/...
-- go get github.com/alecthomas/gometalinter/...
+- go get github.com/alecthomas/gometalinter
 - gometalinter --install --update
 
 script:

--- a/src/github.com/travis-ci/jupiter-brain/server/database.go
+++ b/src/github.com/travis-ci/jupiter-brain/server/database.go
@@ -10,6 +10,8 @@ import (
 	"github.com/travis-ci/jupiter-brain"
 )
 
+const maxOpenDatabaseConnections = 20
+
 type database interface {
 	SaveInstance(*jupiterbrain.Instance) error
 	DestroyInstance(string) error
@@ -29,6 +31,8 @@ func newPGDatabase(url string) (*pgDatabase, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	conn.DB.SetMaxOpenConns(maxOpenDatabaseConnections)
 
 	return &pgDatabase{
 		conn: conn,


### PR DESCRIPTION
This should prevent runaway connection counts in case a connection isn't returned to the pool, or a high number of requests are made at once.

I'm not 100% sure about the exact number "20", but if I recall correctly, that's the pool size we use in other apps?