### PR TITLE
Attempt to terminate instances if an error occurred while cloning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 before_install:
 - go get github.com/constabulary/gb/...
-- go get github.com/alecthomas/gometalinter/...
+- go get github.com/alecthomas/gometalinter
 - gometalinter --install --update
 
 script:


### PR DESCRIPTION
Whenever we don't return an instance from Start(), one shouldn't be left around in vSphere, so make an attempt to find the instance we cloned and then Terminate it if it exists.