### PR TITLE
Improvements to the circuit breaker

### DIFF
--- a/src/github.com/travis-ci/jupiter-brain/vsphere.go
+++ b/src/github.com/travis-ci/jupiter-brain/vsphere.go
@@ -308,6 +308,22 @@ func (i *vSphereInstanceManager) createClient(ctx context.Context) (*govmomi.Cli
 				failureRatio := float64(counts.TotalFailures) / float64(counts.Requests)
 				return counts.Requests >= 5 && failureRatio >= 0.6
 			},
+			OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
+				stateToString := func(state gobreaker.State) string {
+					switch state {
+					case gobreaker.StateClosed:
+						return "closed"
+					case gobreaker.StateHalfOpen:
+						return "half-open"
+					case gobreaker.StateOpen:
+						return "open"
+					default:
+						return "unknown"
+					}
+				}
+
+				i.log.WithField("state_from", stateToString(from)).WithField("state_to", stateToString(to)).Info("circuit breaker state changed")
+			},
 		}),
 	}
 

--- a/src/github.com/travis-ci/jupiter-brain/vsphere.go
+++ b/src/github.com/travis-ci/jupiter-brain/vsphere.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
@@ -301,10 +302,11 @@ func (i *vSphereInstanceManager) createClient(ctx context.Context) (*govmomi.Cli
 	client.Client.RoundTripper = &soapBreakerRoundTripper{
 		rt: client.Client.RoundTripper,
 		cb: gobreaker.NewCircuitBreaker(gobreaker.Settings{
-			Name: "vSphere govmomi",
+			Name:     "vSphere govmomi",
+			Interval: 10 * time.Minute,
 			ReadyToTrip: func(counts gobreaker.Counts) bool {
 				failureRatio := float64(counts.TotalFailures) / float64(counts.Requests)
-				return counts.Requests >= 3 && failureRatio >= 0.6
+				return counts.Requests >= 5 && failureRatio >= 0.6
 			},
 		}),
 	}


### PR DESCRIPTION
This adds some improvements to the circuit breaker between Jupiter Brain and vSphere. From the commit messages:

```
f3ed2d6 (Henrik Hodne, 52 seconds ago)
   Log state changes to circuit breaker

   Without this, it's somewhat invisible when the circuit breaker changes
   states. You'd have to check whenever the worker is starting to get errors.

5fd1f09 (Henrik Hodne, 9 minutes ago)
   Tweak conditions for when the circuit breaker trips

   Previously it would only trip if 60% of all requests since the last time
   the circuit breaker tripped had failed. We send a lot of requests to
   vSphere, and failures don't happen very frequently, so say for example that
   some time has passed since the last failure and we've sent 2000 requests to
   vSphere. If something happens causing all requests to fail, we still need
   to send another 3000 requests before the circuit breaker trips. This commit
   adds an interval to the circuit breaker, meaning the numbers get reset
   every 10 minutes (as long as the circuit breaker is closed).
```
