### PR TITLE
Improve the error messages

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,17 +2,6 @@ package jupiterbrain
 
 import "fmt"
 
-// VSphereAPIError is returned when a function that communicates with the
-// vSphere API gets an error from the API that it can't recover from.
-type VSphereAPIError struct {
-	// UnderlyingError is the error that was returned by the vSphere API.
-	UnderlyingError error
-}
-
-func (e VSphereAPIError) Error() string {
-	return fmt.Sprintf("vSphere API returned error: %s", e.UnderlyingError)
-}
-
 // VirtualMachineNotFoundError is returned if a virtual machine isn't found.
 type VirtualMachineNotFoundError struct {
 	Path string

--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 	"github.com/codegangsta/negroni"
 	"github.com/gorilla/mux"
 	"github.com/meatballhat/negroni-logrus"
+	"github.com/pkg/errors"
 	"github.com/travis-ci/jupiter-brain"
 	"github.com/travis-ci/jupiter-brain/server/jsonapi"
 	"github.com/travis-ci/jupiter-brain/server/negroniraven"
@@ -48,16 +48,16 @@ func newServer(cfg *Config) (*server, error) {
 
 	u, err := url.Parse(cfg.VSphereURL)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to parse vsphere url")
 	}
 
 	if !u.IsAbs() {
-		return nil, fmt.Errorf("vSphere API URL must be absolute")
+		return nil, errors.Errorf("vSphere API URL must be absolute")
 	}
 
 	db, err := newPGDatabase(cfg.DatabaseURL)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to create postgres database")
 	}
 
 	paths := jupiterbrain.VSpherePaths{
@@ -94,7 +94,10 @@ func (srv *server) Setup() {
 
 func (srv *server) Run() {
 	srv.log.WithField("addr", srv.addr).Info("Listening")
-	_ = srv.s.ListenAndServe(srv.addr, srv.n)
+	err := srv.s.ListenAndServe(srv.addr, srv.n)
+	if err != nil {
+		srv.log.WithField("err", err).Error("ListenAndServe failed")
+	}
 }
 
 func (srv *server) setupRoutes() {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -88,6 +88,14 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/pkg/errors",
+			"repository": "https://github.com/pkg/errors",
+			"vcs": "git",
+			"revision": "17b591df37844cde689f4d5813e5cea0927d8dd2",
+			"branch": "HEAD",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/sony/gobreaker",
 			"repository": "https://github.com/sony/gobreaker",
 			"vcs": "",


### PR DESCRIPTION
This uses github.com/pkg/errors liberally to add context to error messages. The messages will remain mostly the same, but the context should make it easier to find out exactly what call failed, instead of just getting a "EOF" or something similar.