### PR TITLE
metrics: log when the librato reporter starts

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -97,6 +97,8 @@ func runServer(c *cli.Context) {
 	logrus.SetFormatter(&logrus.TextFormatter{DisableColors: true})
 
 	if c.IsSet("librato-email") && c.IsSet("librato-token") && c.IsSet("librato-source") {
+		logrus.Info("starting librato metrics reporter")
+
 		go librato.Librato(
 			metrics.DefaultRegistry,
 			time.Minute,


### PR DESCRIPTION
Makes it possible to see if Jupiter Brain picked up the Librato configuration or not. Without this you don't know if metrics not appearing is due to them never being sent due to an error or because the reporter never started.