### PR TITLE
main: work around bug in cli library for flags

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -96,7 +96,7 @@ func main() {
 func runServer(c *cli.Context) {
 	logrus.SetFormatter(&logrus.TextFormatter{DisableColors: true})
 
-	if c.IsSet("librato-email") && c.IsSet("librato-token") && c.IsSet("librato-source") {
+	if c.String("librato-email") != "" && c.String("librato-token") != "" && c.String("librato-source") != "" {
 		logrus.Info("starting librato metrics reporter")
 
 		go librato.Librato(


### PR DESCRIPTION
There's currently a bug in cli that causes `c.IsSet` not to work for flags that are only defined with env vars, so we'll check if the flags are empty instead.