### PR TITLE
Graceful shutdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.6.3
+go: 1.7.1
 sudo: false
 
 env:

--- a/server/server.go
+++ b/server/server.go
@@ -386,10 +386,10 @@ func (srv *server) signalHandler() {
 			switch sig {
 			case syscall.SIGTERM:
 				srv.log.Info("Received SIGTERM, shutting down now.")
-				os.Exit(0)
+				srv.s.Close()
 			case syscall.SIGINT:
 				srv.log.Info("Received SIGINT, shutting down now.")
-				os.Exit(0)
+				srv.s.Close()
 			case syscall.SIGUSR1:
 				srv.log.WithFields(logrus.Fields{
 					"version":   os.Getenv("VERSION"),

--- a/server/server.go
+++ b/server/server.go
@@ -259,7 +259,11 @@ func (srv *server) handleInstancesCreate(w http.ResponseWriter, req *http.Reques
 	recoverDelete := false
 	defer func() {
 		if recoverDelete && instance != nil {
-			go func() { _ = srv.i.Terminate(context.TODO(), instance.ID) }()
+			go func() {
+				srv.s.StartRoutine()
+				defer srv.s.FinishRoutine()
+				srv.i.Terminate(context.TODO(), instance.ID)
+			}()
 		}
 	}()
 

--- a/server/server.go
+++ b/server/server.go
@@ -97,7 +97,9 @@ func (srv *server) Setup() {
 
 func (srv *server) Run() {
 	srv.log.WithField("addr", srv.addr).Info("Listening")
-	err := srv.s.ListenAndServe(srv.addr, srv.n)
+	srv.s.Addr = srv.addr
+	srv.s.Handler = srv.n
+	err := srv.s.ListenAndServe()
 	if err != nil {
 		srv.log.WithField("err", err).Error("ListenAndServe failed")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -80,7 +80,10 @@ func newServer(cfg *Config) (*server, error) {
 
 		n: negroni.New(),
 		r: mux.NewRouter(),
-		s: manners.NewServer(),
+		s: manners.NewWithServer(&http.Server{
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 3 * time.Minute,
+		}),
 
 		db:       db,
 		bootTime: time.Now().UTC(),

--- a/server/server.go
+++ b/server/server.go
@@ -101,7 +101,7 @@ func (srv *server) Setup() {
 func (srv *server) Run() {
 	srv.log.WithField("addr", srv.addr).Info("Listening")
 	srv.s.Addr = srv.addr
-	srv.s.Handler = srv.n
+	srv.s.Handler = http.TimeoutHandler(srv.n, 3*time.Minute, "request timed out")
 	err := srv.s.ListenAndServe()
 	if err != nil {
 		srv.log.WithField("err", err).Error("ListenAndServe failed")

--- a/server/server.go
+++ b/server/server.go
@@ -289,7 +289,10 @@ func (srv *server) handleInstancesCreate(w http.ResponseWriter, req *http.Reques
 	w.Header().Set("Content-Type", "application/vnd.api+json")
 	w.Header().Set("Location", fmt.Sprintf("/instances/%s", instance.ID))
 	w.WriteHeader(http.StatusCreated)
-	fmt.Fprintf(w, string(b)+"\n")
+	_, err = fmt.Fprintf(w, string(b)+"\n")
+	if err != nil {
+		recoverDelete = true
+	}
 }
 
 func (srv *server) handleInstanceByIDFetch(w http.ResponseWriter, req *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -261,7 +261,7 @@ func (srv *server) handleInstancesCreate(w http.ResponseWriter, req *http.Reques
 
 	recoverDelete := false
 	defer func() {
-		if recoverDelete && instance != nil {
+		if (recoverDelete || req.Context().Err() != nil) && instance != nil {
 			go func() {
 				srv.s.StartRoutine()
 				defer srv.s.FinishRoutine()

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
@@ -23,7 +24,6 @@ import (
 	"github.com/travis-ci/jupiter-brain/metrics"
 	"github.com/travis-ci/jupiter-brain/server/jsonapi"
 	"github.com/travis-ci/jupiter-brain/server/negroniraven"
-	"golang.org/x/net/context"
 )
 
 type server struct {
@@ -151,7 +151,7 @@ func (srv *server) authMiddleware(w http.ResponseWriter, req *http.Request, f ht
 func (srv *server) handleInstancesList(w http.ResponseWriter, req *http.Request) {
 	defer metrics.TimeSince("travis.jupiter-brain.endpoints.instances-list", time.Now())
 
-	instances, err := srv.i.List(context.TODO())
+	instances, err := srv.i.List(req.Context())
 	if err != nil {
 		jsonapi.Error(w, err, http.StatusInternalServerError)
 		return
@@ -250,7 +250,7 @@ func (srv *server) handleInstancesCreate(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	instance, err := srv.i.Start(context.TODO(), requestBody["data"]["base-image"])
+	instance, err := srv.i.Start(req.Context(), requestBody["data"]["base-image"])
 	if err != nil {
 		jsonapi.Error(w, err, http.StatusInternalServerError)
 		return
@@ -296,7 +296,7 @@ func (srv *server) handleInstanceByIDFetch(w http.ResponseWriter, req *http.Requ
 	defer metrics.TimeSince("travis.jupiter-brain.endpoints.instance-by-id-fetch", time.Now())
 
 	vars := mux.Vars(req)
-	instance, err := srv.i.Fetch(context.TODO(), vars["id"])
+	instance, err := srv.i.Fetch(req.Context(), vars["id"])
 	if err != nil {
 		switch err.(type) {
 		case jupiterbrain.VirtualMachineNotFoundError:
@@ -331,7 +331,7 @@ func (srv *server) handleInstanceByIDTerminate(w http.ResponseWriter, req *http.
 	defer metrics.TimeSince("travis.jupiter-brain.endpoints.instance-by-id-terminate", time.Now())
 
 	vars := mux.Vars(req)
-	err := srv.i.Terminate(context.TODO(), vars["id"])
+	err := srv.i.Terminate(req.Context(), vars["id"])
 	if err != nil {
 		switch err.(type) {
 		case jupiterbrain.VirtualMachineNotFoundError:
@@ -358,7 +358,7 @@ func (srv *server) handleInstanceByIDTerminate(w http.ResponseWriter, req *http.
 
 func (srv *server) handleInstanceSync(w http.ResponseWriter, req *http.Request) {
 	defer metrics.TimeSince("travis.jupiter-brain.endpoints.instance-sync", time.Now())
-	instances, err := srv.i.List(context.TODO())
+	instances, err := srv.i.List(req.Context())
 	if err != nil {
 		jsonapi.Error(w, err, http.StatusInternalServerError)
 		return

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -11,9 +11,10 @@
 		{
 			"importpath": "github.com/braintree/manners",
 			"repository": "https://github.com/braintree/manners",
-			"vcs": "",
-			"revision": "5280e250f2795914acbeb2bf3b55dd5a2d1fba52",
-			"branch": "HEAD"
+			"vcs": "git",
+			"revision": "82a8879fc5fd0381fa8b2d8033b19bf255252088",
+			"branch": "master",
+			"notests": true
 		},
 		{
 			"importpath": "github.com/codegangsta/cli",


### PR DESCRIPTION
Since we boot/terminate instances in the same process with the HTTP server, we need to make sure to gracefully shut down instead of doing a forceful shutdown, otherwise in-flight requests such as instance creation would be orphaned and the resulting VM would be a "leaked" VM.

We're already using the manners library, which is supposed to implement this, but for it to work we need to call Close() on the GracefulServer instead of just doing os.Exit.

I also updated the manners library to the latest version, since the API changed a bit and there are quite a few improvements.

Fixes #22, #23.

I'd like to attempt to deploy this early next week. We should also make sure that #23 is resolved before deploying this, and maybe add some shorter timeouts, otherwise a restart could take a long time.