### PR TITLE
Add a max concurrency limiter

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -58,10 +58,22 @@ func main() {
 			EnvVar: "JUPITER_BRAIN_VSPHERE_CLUSTER_PATH",
 		},
 		cli.IntFlag{
-			Name:   "vsphere-concurrent-operations",
-			Usage:  "number of concurrent vSphere operations",
-			EnvVar: "JUPITER_BRAIN_VSPHERE_CONCURRENT_OPERATIONS",
-			Value:  100,
+			Name:   "vsphere-concurrent-read-operations",
+			Usage:  "number of concurrent read vSphere operations",
+			EnvVar: "JUPITER_BRAIN_VSPHERE_CONCURRENT_READ_OPERATIONS",
+			Value:  4,
+		},
+		cli.IntFlag{
+			Name:   "vsphere-concurrent-create-operations",
+			Usage:  "number of concurrent create vSphere operations",
+			EnvVar: "JUPITER_BRAIN_VSPHERE_CONCURRENT_CREATE_OPERATIONS",
+			Value:  48,
+		},
+		cli.IntFlag{
+			Name:   "vsphere-concurrent-delete-operations",
+			Usage:  "number of concurrent delete vSphere operations",
+			EnvVar: "JUPITER_BRAIN_VSPHERE_CONCURRENT_DELETE_OPERATIONS",
+			Value:  48,
 		},
 		cli.StringFlag{
 			Name:   "database-url",
@@ -123,11 +135,13 @@ func runServer(c *cli.Context) {
 		Debug:     c.Bool("debug"),
 		SentryDSN: c.String("sentry-dsn"),
 
-		VSphereURL:                  c.String("vsphere-api-url"),
-		VSphereBasePath:             c.String("vsphere-base-path"),
-		VSphereVMPath:               c.String("vsphere-vm-path"),
-		VSphereClusterPath:          c.String("vsphere-cluster-path"),
-		VSphereConcurrentOperations: c.Int("vsphere-concurrent-operations"),
+		VSphereURL:                        c.String("vsphere-api-url"),
+		VSphereBasePath:                   c.String("vsphere-base-path"),
+		VSphereVMPath:                     c.String("vsphere-vm-path"),
+		VSphereClusterPath:                c.String("vsphere-cluster-path"),
+		VSphereConcurrentReadOperations:   c.Int("vsphere-concurrent-read-operations"),
+		VSphereConcurrentCreateOperations: c.Int("vsphere-concurrent-create-operations"),
+		VSphereConcurrentDeleteOperations: c.Int("vsphere-concurrent-delete-operations"),
 
 		DatabaseURL: c.String("database-url"),
 	})

--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -59,19 +59,19 @@ func main() {
 		},
 		cli.IntFlag{
 			Name:   "vsphere-concurrent-read-operations",
-			Usage:  "number of concurrent read vSphere operations",
+			Usage:  "number of concurrent fetch and list operations",
 			EnvVar: "JUPITER_BRAIN_VSPHERE_CONCURRENT_READ_OPERATIONS",
 			Value:  4,
 		},
 		cli.IntFlag{
 			Name:   "vsphere-concurrent-create-operations",
-			Usage:  "number of concurrent create vSphere operations",
+			Usage:  "number of concurrent start operations",
 			EnvVar: "JUPITER_BRAIN_VSPHERE_CONCURRENT_CREATE_OPERATIONS",
 			Value:  48,
 		},
 		cli.IntFlag{
 			Name:   "vsphere-concurrent-delete-operations",
-			Usage:  "number of concurrent delete vSphere operations",
+			Usage:  "number of concurrent terminate operations",
 			EnvVar: "JUPITER_BRAIN_VSPHERE_CONCURRENT_DELETE_OPERATIONS",
 			Value:  48,
 		},

--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -57,6 +57,12 @@ func main() {
 			Usage:  "path to compute cluster that VMs will be booted in",
 			EnvVar: "JUPITER_BRAIN_VSPHERE_CLUSTER_PATH",
 		},
+		cli.IntFlag{
+			Name:   "vsphere-concurrent-operations",
+			Usage:  "number of concurrent vSphere operations",
+			EnvVar: "JUPITER_BRAIN_VSPHERE_CONCURRENT_OPERATIONS",
+			Value:  100,
+		},
 		cli.StringFlag{
 			Name:   "database-url",
 			Usage:  "URL to the PostgreSQL database",
@@ -117,10 +123,11 @@ func runServer(c *cli.Context) {
 		Debug:     c.Bool("debug"),
 		SentryDSN: c.String("sentry-dsn"),
 
-		VSphereURL:         c.String("vsphere-api-url"),
-		VSphereBasePath:    c.String("vsphere-base-path"),
-		VSphereVMPath:      c.String("vsphere-vm-path"),
-		VSphereClusterPath: c.String("vsphere-cluster-path"),
+		VSphereURL:                  c.String("vsphere-api-url"),
+		VSphereBasePath:             c.String("vsphere-base-path"),
+		VSphereVMPath:               c.String("vsphere-vm-path"),
+		VSphereClusterPath:          c.String("vsphere-cluster-path"),
+		VSphereConcurrentOperations: c.Int("vsphere-concurrent-operations"),
 
 		DatabaseURL: c.String("database-url"),
 	})

--- a/server/config.go
+++ b/server/config.go
@@ -21,9 +21,12 @@ type Config struct {
 	VSphereVMPath      string
 	VSphereClusterPath string
 
-	// VSphereConcurrentOperations is the number of concurrent operations Jupiter
-	// Brain has with vSphere at any given time
-	VSphereConcurrentOperations int
+	// The VSphereConcurrent*Operations attributes specify the number of
+	// concurrent read, create and delete operations Jupiter Brain has with
+	// vSphere at any given time.
+	VSphereConcurrentReadOperations   int
+	VSphereConcurrentCreateOperations int
+	VSphereConcurrentDeleteOperations int
 
 	// SentryDSN is used to send errors to Sentry. Leave this blank to not
 	// send errors.

--- a/server/config.go
+++ b/server/config.go
@@ -21,6 +21,10 @@ type Config struct {
 	VSphereVMPath      string
 	VSphereClusterPath string
 
+	// VSphereConcurrentOperations is the number of concurrent operations Jupiter
+	// Brain has with vSphere at any given time
+	VSphereConcurrentOperations int
+
 	// SentryDSN is used to send errors to Sentry. Leave this blank to not
 	// send errors.
 	SentryDSN string

--- a/server/server.go
+++ b/server/server.go
@@ -76,7 +76,7 @@ func newServer(cfg *Config) (*server, error) {
 
 		log: log,
 
-		i: jupiterbrain.NewVSphereInstanceManager(log, u, paths),
+		i: jupiterbrain.NewVSphereInstanceManager(log, u, paths, cfg.VSphereConcurrentOperations),
 
 		n: negroni.New(),
 		r: mux.NewRouter(),

--- a/server/server.go
+++ b/server/server.go
@@ -76,7 +76,14 @@ func newServer(cfg *Config) (*server, error) {
 
 		log: log,
 
-		i: jupiterbrain.NewVSphereInstanceManager(log, u, paths, cfg.VSphereConcurrentOperations),
+		i: jupiterbrain.NewVSphereInstanceManager(
+			log,
+			u,
+			paths,
+			cfg.VSphereConcurrentReadOperations,
+			cfg.VSphereConcurrentCreateOperations,
+			cfg.VSphereConcurrentDeleteOperations,
+		),
 
 		n: negroni.New(),
 		r: mux.NewRouter(),

--- a/vsphere.go
+++ b/vsphere.go
@@ -538,14 +538,23 @@ func (i *vSphereInstanceManager) instanceForVirtualMachine(ctx context.Context, 
 }
 
 func (i *vSphereInstanceManager) requestReadSemaphore(ctx context.Context) (func(), error) {
+	metrics.Gauge("travis.jupiter-brain.semaphore.read.waiting", int64(len(i.readConcurrencySem)))
+	defer metrics.TimeSince("travis.jupiter-brain.semaphore.read.wait-time", time.Now())
+
 	return i.requestSemaphore(ctx, i.readConcurrencySem)
 }
 
 func (i *vSphereInstanceManager) requestCreateSemaphore(ctx context.Context) (func(), error) {
+	metrics.Gauge("travis.jupiter-brain.semaphore.create.waiting", int64(len(i.createConcurrencySem)))
+	defer metrics.TimeSince("travis.jupiter-brain.semaphore.create.wait-time", time.Now())
+
 	return i.requestSemaphore(ctx, i.createConcurrencySem)
 }
 
 func (i *vSphereInstanceManager) requestDeleteSemaphore(ctx context.Context) (func(), error) {
+	metrics.Gauge("travis.jupiter-brain.semaphore.delete.waiting", int64(len(i.deleteConcurrencySem)))
+	defer metrics.TimeSince("travis.jupiter-brain.semaphore.delete.wait-time", time.Now())
+
 	return i.requestSemaphore(ctx, i.deleteConcurrencySem)
 }
 


### PR DESCRIPTION
This adds three concurrency limiters to Jupiter Brain. With the default values, it'll have the following effect:
- No more than 4 concurrent "read" requests (list and fetch, although list requests are incredibly rare, so effectively mostly limiting fetch)
- No more than 48 concurrent "create" requests.
- No more than 48 concurrent "destroy" requests.

Notably the create and destroy requests are considered to be running all the way until the underlying vSphere task is finished, not just when the HTTP request is finished, so if they start to take longer that's gonna provide some pushback and should prevent the snowball effect we see now when things start to get slow and requests time out and requeues happen.

r? @solarce Did we want any more metrics on this? I can't quite remember what we discussed last night, but right now this will log metrics on how many concurrent requests there are at the time of requesting the semaphore, and also how long it takes for something to capture the semaphore.
