### PR TITLE
pprof: move pprof listener to separate port

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -105,10 +105,10 @@ func main() {
 			Usage:  "The source to use when sending metrics to Librato",
 			EnvVar: "JUPITER_BRAIN_LIBRATO_SOURCE,LIBRATO_SOURCE",
 		},
-		cli.BoolFlag{
-			Name:   "enable-pprof",
+		cli.StringFlag{
+			Name:   "pprof-addr",
 			Usage:  "Whether to enable pprof endpoints over HTTP",
-			EnvVar: "JUPITER_BRAIN_ENABLE_PPROF",
+			EnvVar: "JUPITER_BRAIN_PPROF_ADDR",
 		},
 	}
 	app.Action = runServer
@@ -150,6 +150,6 @@ func runServer(c *cli.Context) {
 
 		DatabaseURL: c.String("database-url"),
 
-		EnablePprof: c.Bool("enable-pprof"),
+		PprofAddr: c.String("pprof-addr"),
 	})
 }

--- a/server/config.go
+++ b/server/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	// DatabaseURL is the PostgreSQL database URL wow!
 	DatabaseURL string
 
-	// EnablePprof toggles whether the pprof endpoints from net/http/pprof
-	// should be enabled or not
-	EnablePprof bool
+	// PprofAddr should be a non-empty string specifying where to bind
+	// net/http/pprof endpoints
+	PprofAddr string
 }

--- a/server/server.go
+++ b/server/server.go
@@ -144,6 +144,8 @@ func (srv *server) setupMiddleware() {
 }
 
 func (srv *server) setupPprof() {
+	srv.log.WithField("addr", srv.pprofAddr).Info("enabling pprof")
+
 	pprofMux := http.NewServeMux()
 	pprofMux.HandleFunc(`/debug/pprof/`, pprof.Index)
 	pprofMux.HandleFunc(`/debug/pprof/cmdline`, pprof.Cmdline)

--- a/server/server.go
+++ b/server/server.go
@@ -41,7 +41,7 @@ type server struct {
 	db       database
 	bootTime time.Time
 
-	enablePprof bool
+	pprofAddr string
 }
 
 func newServer(cfg *Config) (*server, error) {
@@ -98,7 +98,7 @@ func newServer(cfg *Config) (*server, error) {
 		db:       db,
 		bootTime: time.Now().UTC(),
 
-		enablePprof: cfg.EnablePprof,
+		pprofAddr: cfg.PprofAddr,
 	}
 
 	return srv, nil
@@ -107,6 +107,9 @@ func newServer(cfg *Config) (*server, error) {
 func (srv *server) Setup() {
 	srv.setupRoutes()
 	srv.setupMiddleware()
+	if srv.pprofAddr != "" {
+		srv.setupPprof()
+	}
 	go srv.signalHandler()
 }
 
@@ -126,19 +129,12 @@ func (srv *server) setupRoutes() {
 	srv.r.HandleFunc(`/instances/{id}`, srv.handleInstanceByIDFetch).Methods("GET").Name("instance-by-id")
 	srv.r.HandleFunc(`/instances/{id}`, srv.handleInstanceByIDTerminate).Methods("DELETE").Name("instance-by-id-terminate")
 	srv.r.HandleFunc(`/instance-syncs`, srv.handleInstanceSync).Methods("POST").Name("instance-syncs-create")
-
-	if srv.enablePprof {
-		srv.r.HandleFunc(`/debug/pprof/`, pprof.Index).Name("pprof-index")
-		srv.r.HandleFunc(`/debug/pprof/cmdline`, pprof.Cmdline).Name("pprof-cmdline")
-		srv.r.HandleFunc(`/debug/pprof/profile`, pprof.Profile).Name("pprof-profile")
-		srv.r.HandleFunc(`/debug/pprof/symbol`, pprof.Symbol).Name("pprof-symbol")
-		srv.r.HandleFunc(`/debug/pprof/trace`, pprof.Trace).Name("pprof-trace")
-	}
 }
 
 func (srv *server) setupMiddleware() {
 	srv.n.Use(negroni.NewRecovery())
 	srv.n.Use(negronilogrus.NewCustomMiddleware(srv.log.Level, srv.log.Formatter, "web"))
+
 	srv.n.Use(negroni.HandlerFunc(srv.authMiddleware))
 	nr, err := negroniraven.NewMiddleware(srv.sentryDSN)
 	if err != nil {
@@ -146,6 +142,22 @@ func (srv *server) setupMiddleware() {
 	}
 	srv.n.Use(nr)
 	srv.n.UseHandler(srv.r)
+}
+
+func (srv *server) setupPprof() {
+	pprofMux := http.NewServeMux()
+	pprofMux.HandleFunc(`/debug/pprof/`, pprof.Index)
+	pprofMux.HandleFunc(`/debug/pprof/cmdline`, pprof.Cmdline)
+	pprofMux.HandleFunc(`/debug/pprof/profile`, pprof.Profile)
+	pprofMux.HandleFunc(`/debug/pprof/symbol`, pprof.Symbol)
+	pprofMux.HandleFunc(`/debug/pprof/trace`, pprof.Trace)
+
+	pprofServer := &http.Server{
+		Addr:    srv.pprofAddr,
+		Handler: pprofMux,
+	}
+
+	go pprofServer.ListenAndServe()
 }
 
 func (srv *server) authMiddleware(w http.ResponseWriter, req *http.Request, f http.HandlerFunc) {

--- a/server/server.go
+++ b/server/server.go
@@ -134,7 +134,6 @@ func (srv *server) setupRoutes() {
 func (srv *server) setupMiddleware() {
 	srv.n.Use(negroni.NewRecovery())
 	srv.n.Use(negronilogrus.NewCustomMiddleware(srv.log.Level, srv.log.Formatter, "web"))
-
 	srv.n.Use(negroni.HandlerFunc(srv.authMiddleware))
 	nr, err := negroniraven.NewMiddleware(srv.sentryDSN)
 	if err != nil {


### PR DESCRIPTION
The pprof handlers don't work well with negroni and middleware, so moving it to a raw http Server should work better.