### PR TITLE
server: add metric for response codes

### DIFF
--- a/server/response_metrics.go
+++ b/server/response_metrics.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/travis-ci/worker/metrics"
+	"github.com/travis-ci/jupiter-brain/metrics"
 )
 
 type metricsResponseWriter struct {

--- a/server/response_metrics.go
+++ b/server/response_metrics.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/travis-ci/worker/metrics"
+)
+
+type metricsResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (mrw *metricsResponseWriter) WriteHeader(code int) {
+	metrics.Mark(fmt.Sprintf("travis.jupiter-brain.response-code.%d", code))
+
+	mrw.ResponseWriter.WriteHeader(code)
+}
+
+func ResponseMetricsHandler(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	next(&metricsResponseWriter{rw}, req)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -134,6 +134,7 @@ func (srv *server) setupRoutes() {
 func (srv *server) setupMiddleware() {
 	srv.n.Use(negroni.NewRecovery())
 	srv.n.Use(negronilogrus.NewCustomMiddleware(srv.log.Level, srv.log.Formatter, "web"))
+	srv.n.UseFunc(ResponseMetricsHandler)
 	srv.n.Use(negroni.HandlerFunc(srv.authMiddleware))
 	nr, err := negroniraven.NewMiddleware(srv.sentryDSN)
 	if err != nil {


### PR DESCRIPTION
This allows us to see how many requests are succeeding/passing/failing/etc.