### PR TITLE
Make the request timeout configurable

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -110,6 +110,12 @@ func main() {
 			Usage:  "Whether to enable pprof endpoints over HTTP",
 			EnvVar: "JUPITER_BRAIN_PPROF_ADDR",
 		},
+		cli.DurationFlag{
+			Name:   "request-timeout",
+			Usage:  "The max time an incoming HTTP request can take before timing out",
+			EnvVar: "JUPITER_BRAIN_REQUEST_TIMEOUT",
+			Value:  3 * time.Minute,
+		},
 	}
 	app.Action = runServer
 
@@ -150,6 +156,7 @@ func runServer(c *cli.Context) {
 
 		DatabaseURL: c.String("database-url"),
 
-		PprofAddr: c.String("pprof-addr"),
+		PprofAddr:      c.String("pprof-addr"),
+		RequestTimeout: c.Duration("request-timeout"),
 	})
 }

--- a/server/config.go
+++ b/server/config.go
@@ -1,5 +1,7 @@
 package server
 
+import "time"
+
 // Config contains everything needed to run the API server.
 type Config struct {
 	// Addr is the address the API should listen on.
@@ -38,4 +40,8 @@ type Config struct {
 	// PprofAddr should be a non-empty string specifying where to bind
 	// net/http/pprof endpoints
 	PprofAddr string
+
+	// RequestTimeout is the maximum amount of time a request is allowed to
+	// take
+	RequestTimeout time.Duration
 }

--- a/server/server.go
+++ b/server/server.go
@@ -41,7 +41,8 @@ type server struct {
 	db       database
 	bootTime time.Time
 
-	pprofAddr string
+	pprofAddr      string
+	requestTimeout time.Duration
 }
 
 func newServer(cfg *Config) (*server, error) {
@@ -98,7 +99,8 @@ func newServer(cfg *Config) (*server, error) {
 		db:       db,
 		bootTime: time.Now().UTC(),
 
-		pprofAddr: cfg.PprofAddr,
+		pprofAddr:      cfg.PprofAddr,
+		requestTimeout: cfg.RequestTimeout,
 	}
 
 	return srv, nil
@@ -116,7 +118,7 @@ func (srv *server) Setup() {
 func (srv *server) Run() {
 	srv.log.WithField("addr", srv.addr).Info("Listening")
 	srv.s.Addr = srv.addr
-	srv.s.Handler = http.TimeoutHandler(srv.n, 3*time.Minute, "request timed out")
+	srv.s.Handler = http.TimeoutHandler(srv.n, srv.requestTimeout, "request timed out")
 	err := srv.s.ListenAndServe()
 	if err != nil {
 		srv.log.WithField("err", err).Error("ListenAndServe failed")


### PR DESCRIPTION
Defaults to 3 minutes, the old value, but is now configurable. This only applies to the timeout for incoming HTTP requests.