### PR TITLE
server: change http write timeout to request timeout + 10 seconds

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,7 @@ func newServer(cfg *Config) (*server, error) {
 		r: mux.NewRouter(),
 		s: manners.NewWithServer(&http.Server{
 			ReadTimeout:  10 * time.Second,
-			WriteTimeout: 3 * time.Minute,
+			WriteTimeout: cfg.RequestTimeout + 10*time.Second,
 		}),
 
 		db:       db,


### PR DESCRIPTION
If the request timeout is longer than the write timeout, the HTTP connection can get closed due to the response not being written in time.