### PR TITLE
Minor fixes to Sentry logic

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	raven "github.com/getsentry/raven-go"
 	librato "github.com/mihasya/go-metrics-librato"
 	metrics "github.com/rcrowley/go-metrics"
 	travismetrics "github.com/travis-ci/jupiter-brain/metrics"
@@ -139,6 +140,8 @@ func runServer(c *cli.Context) {
 		)
 	}
 	go travismetrics.ReportMemstatsMetrics()
+
+	raven.SetDSN(c.String("sentry-dsn"))
 
 	server.Main(&server.Config{
 		Addr:      c.String("addr"),

--- a/vsphere.go
+++ b/vsphere.go
@@ -218,7 +218,9 @@ func (i *vSphereInstanceManager) Start(ctx context.Context, baseName string) (*I
 		err := task.Wait(backgroundCtx)
 		if err != nil {
 			go i.terminateIfExists(backgroundCtx, name.String())
-			raven.CaptureError(err, map[string]string{"vm-name": name.String(), "task": "clone"})
+			if err != context.Canceled && err != context.DeadlineExceeded {
+				raven.CaptureError(err, map[string]string{"vm-name": name.String(), "task": "clone"})
+			}
 			errChan <- errors.Wrap(err, "vm clone task failed")
 			return
 		}
@@ -264,7 +266,9 @@ func (i *vSphereInstanceManager) Start(ctx context.Context, baseName string) (*I
 		err = task.Wait(backgroundCtx)
 		if err != nil {
 			go i.terminateIfExists(backgroundCtx, name.String())
-			raven.CaptureError(err, map[string]string{"vm-name": name.String(), "task": "power-on"})
+			if err != context.Canceled && err != context.DeadlineExceeded {
+				raven.CaptureError(err, map[string]string{"vm-name": name.String(), "task": "power-on"})
+			}
 			errChan <- errors.Wrap(err, "vm power on task failed")
 			return
 		}


### PR DESCRIPTION
Sets the Sentry DSN globally so we can send things to Sentry, and makes sure we don't send errors to Sentry for context cancellations.