### PR TITLE
sentry: set the version in the release field

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -142,6 +142,7 @@ func runServer(c *cli.Context) {
 	go travismetrics.ReportMemstatsMetrics()
 
 	raven.SetDSN(c.String("sentry-dsn"))
+	raven.SetRelease(VersionString)
 
 	server.Main(&server.Config{
 		Addr:      c.String("addr"),


### PR DESCRIPTION
This should let us be able to track which version an error happened in in Sentry.