### PR TITLE
Add some initial Honeycomb support

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -124,6 +124,11 @@ func main() {
 			Usage:  "The write key for Honeycomb",
 			EnvVar: "JUPITER_BRAIN_HONEYCOMB_WRITE_KEY",
 		},
+		cli.StringFlag{
+			Name:   "honeycomb-dataset",
+			Usage:  "The dataset name for Honeycomb",
+			EnvVar: "JUPITER_BRAIN_HONEYCOMB_DATASET",
+		},
 	}
 	app.Action = runServer
 
@@ -148,9 +153,10 @@ func runServer(c *cli.Context) {
 	}
 	go travismetrics.ReportMemstatsMetrics()
 
-	if c.String("honeycomb-write-key") != "" {
+	if c.String("honeycomb-write-key") != "" && c.String("honeycomb-dataset") != "" {
 		libhoney.Init(libhoney.Config{
 			WriteKey: c.String("honeycomb-write-key"),
+			Dataset:  c.String("honeycomb-dataset"),
 		})
 		defer libhoney.Close()
 

--- a/jbcontext/package.go
+++ b/jbcontext/package.go
@@ -1,0 +1,11 @@
+package jbcontext
+
+type contextKey struct {
+	name string
+}
+
+func (k *contextKey) String() string { return "jupiter-brain context value " + k.name }
+
+var (
+	RequestIDKey = &contextKey{"request-id"}
+)

--- a/server/response_metrics.go
+++ b/server/response_metrics.go
@@ -41,6 +41,7 @@ func (mrw *metricsResponseWriter) WriteHeader(code int) {
 		"duration_ms":   float64(time.Now().Sub(mrw.start).Nanoseconds()) / 1000000.0,
 		"method":        mrw.req.Method,
 		"endpoint":      mrw.req.URL.Path,
+		"request_id":    mrw.req.Header.Get("X-Request-ID"),
 		"response_code": code,
 	})
 	if err != nil {
@@ -52,9 +53,10 @@ func (mrw *metricsResponseWriter) WriteHeader(code int) {
 
 func ResponseMetricsHandler(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	err := honeySendEvent(map[string]interface{}{
-		"event":    "started",
-		"method":   req.Method,
-		"endpoint": req.URL.Path,
+		"event":      "started",
+		"method":     req.Method,
+		"endpoint":   req.URL.Path,
+		"request_id": req.Header.Get("X-Request-ID"),
 	})
 	if err != nil {
 		logrus.WithField("err", err).Info("error sending event=started to honeycomb")

--- a/server/response_metrics.go
+++ b/server/response_metrics.go
@@ -24,7 +24,7 @@ func (mrw *metricsResponseWriter) WriteHeader(code int) {
 }
 
 func (mrw *metricsResponseWriter) Write(p []byte) (int, error) {
-	n, err := mrw.Write(p)
+	n, err := mrw.ResponseWriter.Write(p)
 
 	mrw.bytesWritten += int64(n)
 

--- a/server/response_metrics.go
+++ b/server/response_metrics.go
@@ -3,20 +3,51 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"time"
 
+	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/travis-ci/jupiter-brain/metrics"
 )
 
+var (
+	requestHoneycombEventBuilder = libhoney.NewBuilder()
+)
+
+func init() {
+	requestHoneycombEventBuilder.Dataset = "jupiter-brain-requests"
+}
+
 type metricsResponseWriter struct {
 	http.ResponseWriter
+
+	req   *http.Request
+	start time.Time
 }
 
 func (mrw *metricsResponseWriter) WriteHeader(code int) {
 	metrics.Mark(fmt.Sprintf("travis.jupiter-brain.response-code.%d", code))
 
+	requestHoneycombEventBuilder.SendNow(map[string]interface{}{
+		"event":         "finished",
+		"duration_ms":   float64(mrw.start.Sub(time.Now()).Nanoseconds()) / 1000000.0,
+		"method":        mrw.req.Method,
+		"endpoint":      mrw.req.URL.Path,
+		"response_code": code,
+	})
+
 	mrw.ResponseWriter.WriteHeader(code)
 }
 
 func ResponseMetricsHandler(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	next(&metricsResponseWriter{rw}, req)
+	requestHoneycombEventBuilder.SendNow(map[string]interface{}{
+		"event":    "started",
+		"method":   req.Method,
+		"endpoint": req.URL.Path,
+	})
+
+	next(&metricsResponseWriter{
+		ResponseWriter: rw,
+		req:            req,
+		start:          time.Now(),
+	}, req)
 }

--- a/server/response_metrics.go
+++ b/server/response_metrics.go
@@ -38,7 +38,7 @@ func (mrw *metricsResponseWriter) WriteHeader(code int) {
 
 	err := honeySendEvent(map[string]interface{}{
 		"event":         "finished",
-		"duration_ms":   float64(mrw.start.Sub(time.Now()).Nanoseconds()) / 1000000.0,
+		"duration_ms":   float64(time.Now().Sub(mrw.start).Nanoseconds()) / 1000000.0,
 		"method":        mrw.req.Method,
 		"endpoint":      mrw.req.URL.Path,
 		"response_code": code,

--- a/server/response_metrics.go
+++ b/server/response_metrics.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/travis-ci/jupiter-brain/metrics"
 )
@@ -35,7 +34,7 @@ func (mrw *metricsResponseWriter) Write(p []byte) (int, error) {
 func ResponseMetricsHandler(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	mrw := &metricsResponseWriter{
 		ResponseWriter: rw,
-		statusCode:     http.StatusOK,
+		responseCode:   http.StatusOK,
 		bytesWritten:   0,
 	}
 
@@ -47,7 +46,7 @@ func ResponseMetricsHandler(rw http.ResponseWriter, req *http.Request, next http
 		"method":         req.Method,
 		"url_path":       req.URL.Path,
 		"request_id":     req.Header.Get("X-Request-ID"),
-		"response_code":  mrw.statusCode,
+		"response_code":  mrw.responseCode,
 		"total_ms":       float64(time.Since(requestStart).Nanoseconds()) / 1000000.0,
 		"response_bytes": mrw.bytesWritten,
 	})

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -48,6 +48,30 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/facebookgo/clock",
+			"repository": "https://github.com/facebookgo/clock",
+			"vcs": "git",
+			"revision": "600d898af40aa09a7a93ecb9265d87b0504b6f03",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/facebookgo/limitgroup",
+			"repository": "https://github.com/facebookgo/limitgroup",
+			"vcs": "git",
+			"revision": "6abd8d71ec01451d7f1929eacaa263bbe2935d05",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/facebookgo/muster",
+			"repository": "https://github.com/facebookgo/muster",
+			"vcs": "git",
+			"revision": "fd3d7953fd52354a74b9f6b3d70d0c9650c4ec2a",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/getsentry/raven-go",
 			"repository": "https://github.com/getsentry/raven-go",
 			"vcs": "git",
@@ -68,6 +92,14 @@
 			"vcs": "",
 			"revision": "8096f47503459bcc74d1f4c487b7e6e42e5746b5",
 			"branch": "HEAD"
+		},
+		{
+			"importpath": "github.com/honeycombio/libhoney-go",
+			"repository": "https://github.com/honeycombio/libhoney-go",
+			"vcs": "git",
+			"revision": "7a3b7395daf1d2d1ccfcac3e6f7d8f22406509ba",
+			"branch": "master",
+			"notests": true
 		},
 		{
 			"importpath": "github.com/jmoiron/sqlx",
@@ -141,6 +173,14 @@
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
 			"revision": "2cbad5127c61e13d72165f954543a7265625bebb",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "gopkg.in/alexcesaro/statsd.v2",
+			"repository": "https://gopkg.in/alexcesaro/statsd.v2",
+			"vcs": "git",
+			"revision": "7fea3f0d2fab1ad973e641e51dba45443a311a90",
 			"branch": "master",
 			"notests": true
 		}

--- a/vsphere.go
+++ b/vsphere.go
@@ -162,8 +162,10 @@ func (i *vSphereInstanceManager) Start(ctx context.Context, baseName string) (*I
 		honeycombData["total_ms"] = float64(time.Since(startTime).Nanoseconds()) / 1000000.0
 		if err != nil {
 			honeycombData["err"] = err.Error()
+			honeycombData["success"] = 0
+		} else {
+			honeycombData["success"] = 1
 		}
-		honeycombData["success"] = (err == nil)
 		honeycombData["stage"] = stage
 		libhoney.SendNow(honeycombData)
 	}


### PR DESCRIPTION
This PR adds some Honeycomb integration. It sends the following events:

- clone
- terminate
- http-request

All events contain the `X-Request-ID` value if the HTTP header is set (we don't set this anywhere yet, but that way it's tracked when we start to do that).

The HTTP request event has information about the request duration, the HTTP method, URL path (e.g. `/instances/fafafafa-fafa-fafa-fafa-fafafafafafa`), response code (e.g. `200`), and the number of bytes written.

The clone event differs a bit in information depending on how far in the clone it gets. It always has the image name, total duration, whether the clone succeeded or failed (and the error if it failed), and a string field that specifies how far the clone got (roughly "where did the `Start()` method return).

In addition, it tracks this information as it becomes available:

- How long it took to wait for the semaphore "rate limiting"
- The ESXi host name of the host the image is on
- The name of the new VM
- The time it took to "setup" (i.e. the time spent in the `Start` method before the clone is started, which is spent doing things like "find the base VM and snapshot" and "find the resource pool to place the VM in")
- The time it took to run the "clone" task
- The name of the host the VM is on after the clone
- The time it took to run the "power on" task
- The name of the host the VM is on after being powered on

The terminate event is similar in that it tracks more information as it goes along. It also tracks total duration, whether it succeeded or failed, the error, and how far in the method it got before returning. In addition it tracks:

- The name of the VM being terminated
- How long it took to wait for the semaphore "rate limiting"
- If the "power off" errored (we normally ignore this since it could be that the VM is already powered off, which would lead to an error, and since we immediately move on to destroying the VM we assume that that would error too)
- The time it took to run the "power off" task
- The time it took to run the "destroy" task