### PR TITLE
Send stacktrace from errors to Sentry if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.7.1
+go: 1.7.5
 sudo: false
 
 env:

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,8 @@ import (
 	"github.com/travis-ci/jupiter-brain/server/negroniraven"
 )
 
+const ravenStacktraceContextLines = 3
+
 type server struct {
 	addr, authToken, sentryDSN string
 
@@ -498,7 +500,7 @@ func ravenStacktraceFromErr(err error) *raven.Stacktrace {
 				uintptr(frame)-1,
 				fmt.Sprintf("%s", frame),
 				linenumber,
-				3,
+				ravenStacktraceContextLines,
 				[]string{
 					"github.com/travis-ci/jupiter-brain",
 				},


### PR DESCRIPTION
Right now Sentry sends the stacktrace to the place where `raven.CaptureError` is called, which is less useful than the source of the error itself.