### PR TITLE
Use Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.7.5
+go: 1.8
 sudo: false
 
 env:

--- a/server/server.go
+++ b/server/server.go
@@ -13,11 +13,11 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/braintree/manners"
 	"github.com/codegangsta/negroni"
 	raven "github.com/getsentry/raven-go"
 	"github.com/gorilla/mux"
@@ -41,7 +41,9 @@ type server struct {
 
 	n *negroni.Negroni
 	r *mux.Router
-	s *manners.GracefulServer
+	s *http.Server
+
+	backgroundJobs sync.WaitGroup
 
 	db       database
 	bootTime time.Time
@@ -96,10 +98,10 @@ func newServer(cfg *Config) (*server, error) {
 
 		n: negroni.New(),
 		r: mux.NewRouter(),
-		s: manners.NewWithServer(&http.Server{
+		s: &http.Server{
 			ReadTimeout:  10 * time.Second,
 			WriteTimeout: cfg.RequestTimeout + 10*time.Second,
-		}),
+		},
 
 		db:       db,
 		bootTime: time.Now().UTC(),
@@ -125,7 +127,7 @@ func (srv *server) Run() {
 	srv.s.Addr = srv.addr
 	srv.s.Handler = http.TimeoutHandler(srv.n, srv.requestTimeout, "request timed out")
 	err := srv.s.ListenAndServe()
-	if err != nil {
+	if err != nil && err != http.ErrServerClosed {
 		srv.log.WithField("err", err).Error("ListenAndServe failed")
 	}
 }
@@ -319,9 +321,9 @@ func (srv *server) handleInstancesCreate(w http.ResponseWriter, req *http.Reques
 	recoverDelete := false
 	defer func() {
 		if (recoverDelete || req.Context().Err() != nil) && instance != nil {
+			srv.backgroundJobs.Add(1)
 			go func() {
-				srv.s.StartRoutine()
-				defer srv.s.FinishRoutine()
+				defer srv.backgroundJobs.Done()
 				srv.i.Terminate(context.TODO(), instance.ID)
 			}()
 		}
@@ -465,10 +467,12 @@ func (srv *server) signalHandler() {
 			switch sig {
 			case syscall.SIGTERM:
 				srv.log.Info("Received SIGTERM, shutting down now.")
-				srv.s.Close()
+				srv.backgroundJobs.Wait()
+				srv.s.Shutdown(context.Background())
 			case syscall.SIGINT:
 				srv.log.Info("Received SIGINT, shutting down now.")
-				srv.s.Close()
+				srv.backgroundJobs.Wait()
+				srv.s.Shutdown(context.Background())
 			case syscall.SIGUSR1:
 				srv.log.WithFields(logrus.Fields{
 					"version":   os.Getenv("VERSION"),

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -9,14 +9,6 @@
 			"branch": "HEAD"
 		},
 		{
-			"importpath": "github.com/braintree/manners",
-			"repository": "https://github.com/braintree/manners",
-			"vcs": "git",
-			"revision": "82a8879fc5fd0381fa8b2d8033b19bf255252088",
-			"branch": "master",
-			"notests": true
-		},
-		{
 			"importpath": "github.com/certifi/gocertifi",
 			"repository": "https://github.com/certifi/gocertifi",
 			"vcs": "git",


### PR DESCRIPTION
This switches Travis to build using Go 1.8 and also makes use of the main feature I saw that would be useful for Jupiter Brain: The built-in graceful HTTP server shutdown.