### PR TITLE
Pass environment name to Sentry

### DIFF
--- a/cmd/jb-server/main.go
+++ b/cmd/jb-server/main.go
@@ -94,6 +94,11 @@ func main() {
 			EnvVar: "JUPITER_BRAIN_SENTRY_DSN,SENTRY_DSN",
 		},
 		cli.StringFlag{
+			Name:   "sentry-environment",
+			Usage:  "Environment name to pass to Sentry",
+			EnvVar: "JUPITER_BRAIN_SENTRY_ENVIRONMENT,SENTRY_ENVIRONMENT",
+		},
+		cli.StringFlag{
 			Name:   "librato-email",
 			Usage:  "Email for Librato account to send metrics to",
 			EnvVar: "JUPITER_BRAIN_LIBRATO_EMAIL,LIBRATO_EMAIL",
@@ -167,12 +172,16 @@ func runServer(c *cli.Context) {
 
 	raven.SetDSN(c.String("sentry-dsn"))
 	raven.SetRelease(VersionString)
+	if c.String("sentry-environment") != "" {
+		raven.SetEnvironment(c.String("sentry-environment"))
+	}
 
 	server.Main(&server.Config{
-		Addr:      c.String("addr"),
-		AuthToken: c.String("auth-token"),
-		Debug:     c.Bool("debug"),
-		SentryDSN: c.String("sentry-dsn"),
+		Addr:              c.String("addr"),
+		AuthToken:         c.String("auth-token"),
+		Debug:             c.Bool("debug"),
+		SentryDSN:         c.String("sentry-dsn"),
+		SentryEnvironment: c.String("sentry-environment"),
 
 		VSphereURL:                        c.String("vsphere-api-url"),
 		VSphereBasePath:                   c.String("vsphere-base-path"),

--- a/server/config.go
+++ b/server/config.go
@@ -34,6 +34,10 @@ type Config struct {
 	// send errors.
 	SentryDSN string
 
+	// SentryEnvironment is the environment string to use when sending errors
+	// to Sentry. Has no effect if SentryDSN is empty.
+	SentryEnvironment string
+
 	// DatabaseURL is the PostgreSQL database URL wow!
 	DatabaseURL string
 

--- a/server/negroniraven/middleware.go
+++ b/server/negroniraven/middleware.go
@@ -14,10 +14,14 @@ type Middleware struct {
 	log *logrus.Logger
 }
 
-func NewMiddleware(sentryDSN string) (*Middleware, error) {
+func NewMiddleware(sentryDSN, environment string) (*Middleware, error) {
 	cl, err := raven.NewClient(sentryDSN, SentryTags)
 	if err != nil {
 		return nil, err
+	}
+
+	if environment != "" {
+		cl.SetEnvironment(environment)
 	}
 
 	log := logrus.New()

--- a/server/server.go
+++ b/server/server.go
@@ -33,7 +33,7 @@ import (
 const ravenStacktraceContextLines = 3
 
 type server struct {
-	addr, authToken, sentryDSN string
+	addr, authToken, sentryDSN, sentryEnvironment string
 
 	log *logrus.Logger
 
@@ -79,9 +79,10 @@ func newServer(cfg *Config) (*server, error) {
 	}
 
 	srv := &server{
-		addr:      cfg.Addr,
-		authToken: cfg.AuthToken,
-		sentryDSN: cfg.SentryDSN,
+		addr:              cfg.Addr,
+		authToken:         cfg.AuthToken,
+		sentryDSN:         cfg.SentryDSN,
+		sentryEnvironment: cfg.SentryEnvironment,
 
 		log: log,
 
@@ -151,7 +152,7 @@ func (srv *server) setupMiddleware() {
 	})
 	srv.n.UseFunc(ResponseMetricsHandler)
 	srv.n.Use(negroni.HandlerFunc(srv.authMiddleware))
-	nr, err := negroniraven.NewMiddleware(srv.sentryDSN)
+	nr, err := negroniraven.NewMiddleware(srv.sentryDSN, srv.sentryEnvironment)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Passing in the environment name allows us to notice if an error affects one environment over another, or we could potentially ignore alerts for staging warnings, or send them elsewhere, etc.