### PR TITLE
Fix runtime panic in Sentry stacktrace creator

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -506,7 +506,9 @@ func ravenStacktraceFromErr(err error) *raven.Stacktrace {
 					"github.com/travis-ci/jupiter-brain",
 				},
 			)
-			stacktrace.Frames = append(stacktrace.Frames, newframe)
+			if newframe != nil {
+				stacktrace.Frames = append(stacktrace.Frames, newframe)
+			}
 		}
 
 		return stacktrace


### PR DESCRIPTION
The frame returned by NewStacktraceFrame can be nil in certain cases, for example for `runtime.goexit`. The `raven.NewStacktrace` function handles them by just skipping over them in the stacktrace, so let's port that into this as well.