### PR TITLE
Allow configuring CPUs and RAM for created VMs

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 // Instance is our representation of an instance woop woop
@@ -33,4 +34,18 @@ type InstanceConfig struct {
 	// If RAM is 0, the amount of RAM will not be changed from what is configured in the
 	// base image.
 	RAM int `json:"ram"`
+}
+
+// ConfigSpec constructs a spec for reconfiguring the VM after it is cloned.
+// ConfigSpec returns nil if none of the config parameters for the VM are set.
+// In that case, no reconfigure task for the VM should be run.
+func (c InstanceConfig) ConfigSpec() *types.VirtualMachineConfigSpec {
+	if c.CPUCount == 0 && c.RAM == 0 {
+		return nil
+	}
+
+	return &types.VirtualMachineConfigSpec{
+		NumCPUs:  int32(c.CPUCount),
+		MemoryMB: int64(c.RAM),
+	}
 }

--- a/instance.go
+++ b/instance.go
@@ -14,3 +14,23 @@ type Instance struct {
 	CreatedAt   time.Time   `db:"created_at"`
 	DestroyedAt pq.NullTime `db:"destroyed_at"`
 }
+
+// InstanceConfig specifies how a new instance should be configured
+type InstanceConfig struct {
+	// Type is the type of data in the payload and is required to be "instances".
+	// The endpoint for creating new instances will check this value for correctness.
+	Type string `json:"type"`
+
+	// BaseImage is the VM name of the image the new instance will be cloned from.
+	BaseImage string `json:"base-image"`
+
+	// CPUCount is the number of CPUs the new instance should have.
+	// If CPUCount is 0, the number of CPUs will not be changed from what is configured
+	// in the base image.
+	CPUCount int `json:"cpus"`
+
+	// RAM is the amount of RAM in MB that the new instance should have.
+	// If RAM is 0, the amount of RAM will not be changed from what is configured in the
+	// base image.
+	RAM int `json:"ram"`
+}

--- a/instance_manager.go
+++ b/instance_manager.go
@@ -6,6 +6,6 @@ import "context"
 type InstanceManager interface {
 	Fetch(context.Context, string) (*Instance, error)
 	List(context.Context) ([]*Instance, error)
-	Start(context.Context, string) (*Instance, error)
+	Start(context.Context, InstanceConfig) (*Instance, error)
 	Terminate(context.Context, string) error
 }

--- a/server/server.go
+++ b/server/server.go
@@ -280,7 +280,7 @@ func (srv *server) handleInstancesList(w http.ResponseWriter, req *http.Request)
 func (srv *server) handleInstancesCreate(w http.ResponseWriter, req *http.Request) {
 	defer metrics.TimeSince("travis.jupiter-brain.endpoints.instances-create", time.Now())
 
-	var requestBody map[string]map[string]string
+	var requestBody map[string]*jupiterbrain.InstanceConfig
 
 	err := json.NewDecoder(req.Body).Decode(&requestBody)
 	if err != nil {
@@ -293,17 +293,17 @@ func (srv *server) handleInstancesCreate(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	if requestBody["data"]["type"] != "instances" {
+	if requestBody["data"].Type != "instances" {
 		jsonapi.Error(w, &jsonapi.JSONError{Status: "409", Code: "incorrect-type", Title: "data must be of type instances"}, http.StatusConflict)
 		return
 	}
 
-	if requestBody["data"]["base-image"] == "" {
+	if requestBody["data"].BaseImage == "" {
 		jsonapi.Error(w, &jsonapi.JSONError{Status: "422", Code: "missing-field", Title: "instance must have base-image field"}, 422)
 		return
 	}
 
-	instance, err := srv.i.Start(req.Context(), requestBody["data"]["base-image"])
+	instance, err := srv.i.Start(req.Context(), *requestBody["data"])
 	if err != nil {
 		ravenHTTP := raven.NewHttp(req)
 		ravenHTTP.Data = requestBody["data"]

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,7 +19,7 @@ func (i fakeInstanceManager) List(ctx context.Context) ([]*jupiterbrain.Instance
 	return []*jupiterbrain.Instance{}, nil
 }
 
-func (i fakeInstanceManager) Start(ctx context.Context, image string) (*jupiterbrain.Instance, error) {
+func (i fakeInstanceManager) Start(ctx context.Context, config jupiterbrain.InstanceConfig) (*jupiterbrain.Instance, error) {
 	return nil, nil
 }
 

--- a/vsphere.go
+++ b/vsphere.go
@@ -150,11 +150,11 @@ func (i *vSphereInstanceManager) List(ctx context.Context) ([]*Instance, error) 
 	return instances, nil
 }
 
-func (i *vSphereInstanceManager) Start(ctx context.Context, baseName string) (*Instance, error) {
+func (i *vSphereInstanceManager) Start(ctx context.Context, config InstanceConfig) (*Instance, error) {
 	startTime := time.Now()
 	honeycombData := map[string]interface{}{
 		"event":      "clone",
-		"image_name": baseName,
+		"image_name": config.BaseImage,
 		"request_id": ctx.Value(jbcontext.RequestIDKey),
 	}
 
@@ -189,7 +189,7 @@ func (i *vSphereInstanceManager) Start(ctx context.Context, baseName string) (*I
 		return nil, err
 	}
 
-	vm, snapshotTree, err := i.findBaseVMAndSnapshot(ctx, baseName)
+	vm, snapshotTree, err := i.findBaseVMAndSnapshot(ctx, config.BaseImage)
 	if err != nil {
 		honeycombSend("find_base_vm_and_snapshot", err)
 		return nil, errors.Wrap(err, "failed to find base VM and snapshot")


### PR DESCRIPTION
Adds some new optional fields to the create instance request payload: `cpus` and `ram`. If either is present, the instance will be reconfigured appropriately to have a different number of CPUs or different amount of RAM. Any field that isn't set will default to what the base VM has.

The intention is that we will make changes in worker to be able to experiment with these parameters, and eventually introduce rules that change this based on the job.